### PR TITLE
Implement Vault Page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,8 @@
+import 'package:cyber_vault/pages/credit_card_page.dart';
+import 'package:cyber_vault/pages/documents_page.dart';
+import 'package:cyber_vault/pages/passwords_page.dart';
+import 'package:cyber_vault/pages/personal_info_page.dart';
+import 'package:cyber_vault/pages/secure_notes.dart';
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -28,6 +33,11 @@ class MyApp extends StatelessWidget {
           '/login': (context) => const LoginPage(),
           '/signUp': (context) => const SignUpPage(),
           '/home': (context) => const HomePage(),
+          '/passwords': (context) => const PasswordsPage(),
+          '/personal_info': (context) => const PersonalInfoPage(),
+          '/secure_notes': (context) => const SecureNotesPage(),
+          '/documents': (context) => const DocumentsPage(),
+          '/credit_card': (context) => const CreditCardPage()
         },
         theme: ThemeData(
           colorScheme:

--- a/lib/pages/credit_card_page.dart
+++ b/lib/pages/credit_card_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class CreditCardPage extends StatelessWidget {
+  const CreditCardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: null,
+        ),
+        body: const Center(child: Text("Credit Card Page To be implemented")));
+  }
+}

--- a/lib/pages/documents_page.dart
+++ b/lib/pages/documents_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class DocumentsPage extends StatelessWidget {
+  const DocumentsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: null,
+        ),
+        body: const Center(child: Text("Documents Page To be implemented")));
+  }
+}

--- a/lib/pages/passwords_page.dart
+++ b/lib/pages/passwords_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class PasswordsPage extends StatelessWidget {
+  const PasswordsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: null,
+        ),
+        body: const Center(child: Text("Passwords Page To be implemented")));
+  }
+}

--- a/lib/pages/personal_info_page.dart
+++ b/lib/pages/personal_info_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class PersonalInfoPage extends StatelessWidget {
+  const PersonalInfoPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: null,
+        ),
+        body:
+            const Center(child: Text("Personal Info Page To be implemented")));
+  }
+}

--- a/lib/pages/secure_notes.dart
+++ b/lib/pages/secure_notes.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class SecureNotesPage extends StatelessWidget {
+  const SecureNotesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: null,
+        ),
+        body: const Center(child: Text("Secure Notes Page To be implemented")));
+  }
+}

--- a/lib/pages/vault_page.dart
+++ b/lib/pages/vault_page.dart
@@ -9,6 +9,67 @@ class VaultPage extends StatelessWidget {
         appBar: AppBar(
           title: null,
         ),
-        body: const Center(child: Text("Vault Page To be implemented")));
+        body: ListView(children: <Widget>[
+          Card(
+              child: ListTile(
+            onTap: () {
+              Navigator.pushNamed(context, '/passwords');
+            },
+            leading: const Icon(Icons.vpn_key, size: 25),
+            title: const Text('Passwords'),
+            subtitle: const Text('Manage your login passwords.'),
+            trailing: const Icon(Icons.chevron_right),
+            isThreeLine: false,
+          )),
+          Card(
+            child: ListTile(
+              onTap: () {
+                Navigator.pushNamed(context, '/credit_card');
+              },
+              leading:
+                  const Icon(Icons.credit_card, size: 25), // Credit Card Icon
+              title: const Text('Credit Cards'),
+              subtitle: const Text('Manage your credit card information.'),
+              trailing: const Icon(Icons.chevron_right),
+              isThreeLine: false,
+            ),
+          ),
+          Card(
+            child: ListTile(
+              onTap: () {
+                Navigator.pushNamed(context, '/documents');
+              },
+              leading: const Icon(Icons.description, size: 25), // Document Icon
+              title: const Text('Documents'),
+              subtitle: const Text('Access and organize your documents.'),
+              trailing: const Icon(Icons.chevron_right),
+              isThreeLine: false,
+            ),
+          ),
+          Card(
+            child: ListTile(
+              onTap: () {
+                Navigator.pushNamed(context, '/secure_notes');
+              },
+              leading: const Icon(Icons.lock, size: 25), // Secure Note Icon
+              title: const Text('Secure Notes'),
+              subtitle: const Text('Store your confidential notes securely.'),
+              trailing: const Icon(Icons.chevron_right),
+              isThreeLine: false,
+            ),
+          ),
+          Card(
+            child: ListTile(
+              onTap: () {
+                Navigator.pushNamed(context, '/personal_info');
+              },
+              leading: const Icon(Icons.person, size: 25), // Personal Info Icon
+              title: const Text('Personal Info'),
+              subtitle: const Text('Manage your personal information.'),
+              trailing: const Icon(Icons.chevron_right),
+              isThreeLine: false,
+            ),
+          ),
+        ]));
   }
 }

--- a/lib/widgets/search_bar.dart
+++ b/lib/widgets/search_bar.dart
@@ -30,6 +30,7 @@ class _SearchBarWidgetState extends State<SearchBarWidget> {
           trailing: const <Widget>[
             IconButton(
               icon: CircleAvatar(
+                radius: 20,
                 backgroundImage: NetworkImage(
                     "https://ui-avatars.com/api/?name=Affan+Chaudhary&rounded=true"),
               ),


### PR DESCRIPTION

This pull request addresses Issue #7 : Implement Vault Page Interface.

### Changes Made
I have implemented the `VaultPage` interface, which includes the following features:
- Display cards with icons and titles for different vault categories (e.g., Passwords, Credit Cards, Documents, Secure Notes, Personal Info).
- Enable navigation to respective pages when tapping on each card.

### Testing Done
I have tested the `VaultPage` interface thoroughly to ensure it functions as expected. All links to specific pages are working as intended.


### Checklist
- [x] Implemented `VaultPage` interface.
- [x] Tested the feature to ensure functionality.

